### PR TITLE
Removing wsgiref from the requirements due to problems installing it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 Django==1.7.1
-wsgiref==0.1.2


### PR DESCRIPTION
it should be installed with python anyway, so we'll deal with this if it becomes an issue
