### PR TITLE
Added Python social auth through Github 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,15 @@ Mockup
 ======
 
 https://moqups.com/superbibi101/uxDjnbyA
+
+Configure Python social authentication
+======================================
+1. In Github go to Personal Settings/Applications -> Register new application
+Application name = TrackCatz
+Homepage URL = http://localhost:8000/
+Application Descrition = TrackCatz application
+Application callback URL = http://localhost:8000/
+2. In your local TrackCat directory create settings_local.py and add two lines:
+SOCIAL_AUTH_GITHUB_KEY = 'enter Client ID from your github registered app '
+SOCIAL_AUTH_GITHUB_SECRET = 'enter Client Secret from your github registered app'
+

--- a/README.md
+++ b/README.md
@@ -31,14 +31,22 @@ Mockup
 
 https://moqups.com/superbibi101/uxDjnbyA
 
-Configure Python social authentication
+Install and Configure Python social authentication
 ======================================
-1. In Github go to Personal Settings/Applications -> Register new application
+Perform steps 1., 2. in 3. in your virtual environment.
+1. Install the requirements:
+pip install -r requirements.txt
+2. Sync database to create needed models:
+./manage.py makemigrations 
+./manage.py syncdb
+3. Run server: 
+./manage.py runserver
+4. In Github go to Personal Settings/Applications -> Register new application
 Application name = TrackCatz
 Homepage URL = http://localhost:8000/
 Application Descrition = TrackCatz application
 Application callback URL = http://localhost:8000/
-2. In your local TrackCat directory create settings_local.py and add two lines:
+5. In your local TrackCat directory create settings_local.py and add two lines:
 SOCIAL_AUTH_GITHUB_KEY = 'enter Client ID from your github registered app '
 SOCIAL_AUTH_GITHUB_SECRET = 'enter Client Secret from your github registered app'
 

--- a/TrackCat/settings.py
+++ b/TrackCat/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = (
 	'django.contrib.sessions',
 	'django.contrib.messages',
 	'django.contrib.staticfiles',
+	'social.apps.django_app.default',
 
 	# defined apps
 	'web',
@@ -55,10 +56,32 @@ MIDDLEWARE_CLASSES = (
 	'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
 
+########## AUTHENTICATION CONFIGURATION
+AUTHENTICATION_BACKENDS = (
+	'social.backends.github.GithubOAuth2',
+	'django.contrib.auth.backends.ModelBackend',
+)
+
 TEMPLATE_CONTEXT_PROCESSORS = (
 	'django.contrib.auth.context_processors.auth',
 	'django.core.context_processors.request',
+	'social.apps.django_app.context_processors.backends',
+	'social.apps.django_app.context_processors.login_redirect',
 )
+
+AUTH_PROFILE_MODULE = 'api.UserProfile'
+
+LOGIN_URL = '/login/'
+
+LOGIN_REDIRECT_URL = '/'
+LOGIN_ERROR_URL = '/login-error/'
+
+SOCIAL_AUTH_NEW_USER_REDIRECT_URL = '/'
+SOCIAL_AUTH_ENABLED_BACKENDS = ('github')
+SOCIAL_AUTH_DEFAULT_USERNAME = 'new_social_auth_user'
+SOCIAL_AUTH_GITHUB_KEY = ''
+SOCIAL_AUTH_GITHUB_SECRET = ''
+########## END AUTHENTICATION CONFIGURATION
 
 ROOT_URLCONF = 'TrackCat.urls'
 
@@ -100,3 +123,4 @@ try:
 	from .settings_local import *
 except ImportError as e:
 	pass
+

--- a/TrackCat/urls.py
+++ b/TrackCat/urls.py
@@ -4,4 +4,5 @@ from django.contrib import admin
 urlpatterns = patterns('',
 	url(r'^admin/', include(admin.site.urls)),
 	url(r'', include('web.urls')),
+	url('', include('social.apps.django_app.urls', namespace='social')),
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,12 @@
 Django==1.7.1
-wsgiref==0.1.2
 Pillow==2.7.0
+PyJWT==0.4.1
+argparse==1.2.1
+oauthlib==0.7.2
+python-openid==2.2.5
+python-social-auth==0.2.1
+requests==2.5.1
+requests-oauthlib==0.4.2
+six==1.9.0
+wsgiref==0.1.2
+

--- a/web/templates/pages/login.html
+++ b/web/templates/pages/login.html
@@ -4,14 +4,20 @@
 
 {% block content%}
 
-	<header class="row">
-		<h4>CodeCatz Login</h4>
-		<p>This page will show Login for our members.</p>
-	</header>
-	<div class="row">
-		<p> Already logged in?
-		<a href="{% url 'pages-edituser' %}" class="btn btn-default">Edit your profile</a>
+<div class="container">
+	<div class="text-center">
+		<h1>Login to TrackCatz with your Github account</h1>
+		<p>We make it easier so you don't have to remember yet another password
+			<i class="fa fa-smile-o"></i>
 		</p>
 	</div>
+	<div class="login-body">
+		<a href="{% url 'social:begin' 'github' %}"
+		class="btn btn-block btn-social btn-lg btn-github">
+		<i class="fa fa-github-square"></i> Sign in with Github
+		</a>
+	</div>
+</div>
 
 {% endblock content%}
+

--- a/web/templates/pages/login.html
+++ b/web/templates/pages/login.html
@@ -5,6 +5,7 @@
 {% block content%}
 
 <div class="container">
+{% if not user.is_authenticated %}
 	<div class="text-center">
 		<h1>Login to TrackCatz with your Github account</h1>
 		<p>We make it easier so you don't have to remember yet another password
@@ -19,5 +20,20 @@
 	</div>
 </div>
 
+{% else %}
+	<div class="logged-in">
+	<div class="alert alert-info"><p>Looks like you already signed in!</p></div>
+	<h1 class="username">
+	{% if user.first_name or user.last_name %}
+		{{ user.first_name }} {{ user.last_name }}
+	{% else %}
+		{{ user.username }}
+	{% endif %}
+	</a>
+	</h1>
+	</div>
+	<p>I want to sign out pls!</p>
+	<a href="{% url 'logout' %}" <i class="btn btn-primary btn-directional fa fa-sign-out btn-lg"></i>Logout</a></p>
+{% endif %}
 {% endblock content%}
 

--- a/web/urls.py
+++ b/web/urls.py
@@ -16,4 +16,5 @@ urlpatterns = patterns('',
 	url(r'^edituser/$', views.edituser, name='pages-edituser'),
 	url(r'^privacy/$', views.privacy, name='pages-privacy'),
 	url(r'^project/(?P<project_id>[0-9]+)/$', views.project_detail),
+	url(r'^logout/$', views.logout, name='logout'),
 )

--- a/web/views.py
+++ b/web/views.py
@@ -1,6 +1,7 @@
 from django.template import RequestContext
-from django.shortcuts import render_to_response, render, get_object_or_404
+from django.shortcuts import render_to_response, render, get_object_or_404, redirect
 from api.models import Project
+from django.contrib.auth import logout as auth_logout
 
 def index(request):
 	return render_to_response('pages/index.html',{})
@@ -36,3 +37,8 @@ def privacy(request):
 def project_detail(request,project_id):
 	project = get_object_or_404(Project, project_id=project_id)
 	return render(request, 'pages/project_detail.html', {'project': project})
+
+def logout(request):
+    auth_logout(request)
+    return redirect('/')
+


### PR DESCRIPTION
Solved issue #118 . Added Python social auth through Github. You can login using the link on the Login/Profile page. The login link (Sign in to Github) will redirect you to the index (main) page. If you go back to the Login/Profile page it will show you are already signed in and will display your first and last name and give you the possibility to sign out. 

Make sure you follow README.md file to setup your settings_local.py file. 