### PR TITLE
Changed members page to display username, if user does not have first name/last name set

### DIFF
--- a/web/templates/pages/members.html
+++ b/web/templates/pages/members.html
@@ -42,7 +42,14 @@
 						{% if member.profile_picture %}
 							<img src="{{ MEDIA_URL }}{{ member.profile_picture.url|default_if_none:"" }}" alt="{{ member.user.first_name }}" />
 						{% endif %}
-						{{ member.user.first_name }} {{ member.user.last_name }}
+						{% if member.user.first_name %}
+							{{ member.user.first_name }} 
+						{% else %}
+							{{ member.user.username }}
+						{% endif %}
+						{% if member.user.last_name %}
+							{{ member.user.last_name }}
+						{% endif %}							
 					</a> 
 					{{ member.get_activity_status_display }}
 					<li>


### PR DESCRIPTION
To address #203 issue changed members page, added if/else for display of username in case first name/last name is missing for the user