### PR TITLE
Handle editprofile page error, when userprofile object does not exist

### DIFF
--- a/web/templates/pages/edituser.html
+++ b/web/templates/pages/edituser.html
@@ -1,14 +1,18 @@
 {% extends 'base.html' %}
-
 {% load staticfiles %}
 
 {% block title %}Update member{% endblock %}
 
 {% block content%}
 
-	<form enctype="multipart/form-data" method="POST">{% csrf_token %}
-		{{ userprofileform.as_p }}
-		<button type="submit" class="save btn btn-default">Save</button>
-	</form>
+	{% if invalid_userprofile %}
+		<p class="alert alert-warning">This member does not exist.</p>
+		<p>Return to <a href="{% url 'pages-members' %}">Members</a></p>
+	{%  else %}	
+		<form enctype="multipart/form-data" method="POST">{% csrf_token %}
+			{{ userprofileform.as_p }}
+			<button type="submit" class="save btn btn-default">Save</button>
+		</form>
+	{% endif %}	
 
 {% endblock content %}

--- a/web/views.py
+++ b/web/views.py
@@ -27,7 +27,11 @@ def member_page(request,user_id):
 
 @login_required
 def user_edit(request):
-	userprofile = UserProfile.objects.get(user=request.user)
+	if UserProfile.objects.filter(user=request.user).exists():
+		userprofile = UserProfile.objects.get(user=request.user)
+	else:
+		return render(request, 'pages/edituser.html', {'invalid_userprofile': True})
+
 	if request.method == "POST":
 		userprofileform = UserProfileForm(request.POST, request.FILES, instance=userprofile)
 		if userprofileform.is_valid():
@@ -37,7 +41,6 @@ def user_edit(request):
 		userprofileform = UserProfileForm(instance=userprofile)
 
 	return render(request, 'pages/edituser.html', {'userprofileform': userprofileform})	
-
 
 def tasks(request):
 	task_list = Task.objects.all()


### PR DESCRIPTION
Display an error, in case of going to editprofile page with (for some reason) a non-existing userprofile