### PR TITLE
Add delete functionality to the projects

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -35,6 +35,7 @@ PROJECT_STATUS_CHOICES = (
 	('OPENED', 'Opened'),
 	('INPROGRESS', 'In progress'),
 	('CLOSED', 'Closed'),
+	('DELETED', 'Deleted'),
 )
 
 class Project(models.Model):
@@ -59,6 +60,7 @@ STATUS_CHOICES = (
 	('ASSIGNED', 'Assigned'),
 	('WORKINGON', 'Working On'),
 	('COMPLETED', 'Completed'),
+	('DELETED', 'Deleted'),
 )
 
 class Task (models.Model):

--- a/web/form.py
+++ b/web/form.py
@@ -1,6 +1,6 @@
 from django import forms
 from api.models import UserProfile
-from api.models import Project
+from api.models import Project, PROJECT_STATUS_CHOICES
 from api.models import Task
 
 class TaskForm(forms.ModelForm):
@@ -142,3 +142,7 @@ class ProjectForm(forms.ModelForm):
 					'invalid': u'Please check if this is valid',
 				},
 			}
+
+	def __init__(self, *args, **kwargs):
+		self.base_fields['status'].choices = PROJECT_STATUS_CHOICES[:3]
+		super(ProjectForm, self).__init__(*args, **kwargs)	

--- a/web/templates/pages/project_detail.html
+++ b/web/templates/pages/project_detail.html
@@ -11,6 +11,9 @@
 				{% if perms.api.change_project %}					
 					<a class="btn btn-default" href="{% url 'project-edit' project_id=project.project_id %}"><span class="glyphicon glyphicon-pencil"> Edit</span></a>
 				{% endif %}
+				{% if perms.api.delete_project %}					
+					<a class="btn btn-default" href="{% url 'project-delete' project_id=project.project_id %}"><span class="glyphicon glyphicon-remove"> Delete</span></a>
+				{% endif %}
 			</div>
 		</div>
 		<div class="row">

--- a/web/urls.py
+++ b/web/urls.py
@@ -21,6 +21,6 @@ urlpatterns = patterns('',
 	url(r'^project/(?P<project_id>[0-9]+)/$',views.project_detail, name='project-detail'),
 	url(r'^project/new/$', views.project_new, name='project-new'),
 	url(r'^project/(?P<project_id>[0-9]+)/edit/$', views.project_edit, name='project-edit'),
+	url(r'^project/(?P<project_id>[0-9]+)/delete/$', views.project_delete, name='project-delete'),
 	url(r'^logout/$', views.logout, name='logout'),
 )
-

--- a/web/views.py
+++ b/web/views.py
@@ -12,7 +12,7 @@ def index(request):
 	return render(request, 'pages/index.html',{})
 
 def projects(request):
-	project_list = Project.objects.all()
+	project_list = Project.objects.all().exclude(status = 'DELETED')
 	return render(request, 'pages/projects.html',{'project_list': project_list})
 
 def about(request):
@@ -95,7 +95,7 @@ def links(request):
 	return render(request, 'pages/links.html',{})
 
 def project_detail(request, project_id):
-	if Project.objects.filter(pk=project_id).exists():
+	if Project.objects.filter(pk=project_id).exclude(status = 'DELETED').exists():
 		project = Project.objects.get(pk=project_id)
 	else:
 		project = None
@@ -131,6 +131,15 @@ def project_edit(request, project_id):
 
 	return render(request, 'pages/project_edit.html', {'projectform': projectform,
 														'editing': True})
+
+@permission_required('api.delete_project', login_url='/login/')
+def project_delete(request, project_id):
+	project = Project.objects.get(pk=project_id)
+		
+	project.status = 'DELETED'
+
+	project.save()
+	return redirect('pages-projects')
 
 def logout(request):
 	auth_logout(request)


### PR DESCRIPTION
Add delete functionality to the projects: 
Restrict the all projects page to not show the "deleted" ones
Restrict the project detail view page to not show the "deleted" ones, if accessed from direct url
Certainly  would be more secure and friendly to ask the user to confirm the delete, but at the moment I was able to do only like this.
Closes: #199 