### PR TITLE
Url string to the google font changed

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -6,7 +6,7 @@
 <html>
 <head>
 	<title>TrackCat - {% block title %}TrackCat{% endblock %}</title>
-	<link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Open+Sans:400,600,300">
+	<link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:400,600,300">
 	<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
 	<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap-theme.min.css">
 	<link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">


### PR DESCRIPTION
Reason: Heroku are using https for google fonts